### PR TITLE
Adding pulling Classifier Config from CentOps

### DIFF
--- a/src/Dmr.Api/Services/CentOps/CentOpsService.cs
+++ b/src/Dmr.Api/Services/CentOps/CentOpsService.cs
@@ -19,5 +19,10 @@ namespace Dmr.Api.Services.CentOps
                     ? new Uri(participants[name].Host!)
                     : null);
         }
+
+        public Task<IEnumerable<Participant>> FetchParticipantsByType(ParticipantType type)
+        {
+            return Task.FromResult(participants.Values.Where(p => p.Type == type));
+        }
     }
 }

--- a/src/Dmr.Api/Services/CentOps/ICentOpsService.cs
+++ b/src/Dmr.Api/Services/CentOps/ICentOpsService.cs
@@ -6,5 +6,7 @@
     public interface ICentOpsService
     {
         Task<Uri?> FetchEndpointByName(string name);
+
+        Task<IEnumerable<Participant>> FetchParticipantsByType(ParticipantType type);
     }
 }

--- a/src/Dmr.Api/Services/CentOps/Participant.cs
+++ b/src/Dmr.Api/Services/CentOps/Participant.cs
@@ -7,5 +7,7 @@
         public string? Name { get; set; }
 
         public string? Host { get; set; }
+
+        public ParticipantType Type { get; set; }
     }
 }

--- a/src/Dmr.Api/Services/CentOps/ParticipantTypes.cs
+++ b/src/Dmr.Api/Services/CentOps/ParticipantTypes.cs
@@ -1,0 +1,10 @@
+﻿namespace Dmr.Api.Services.CentOps
+{
+    public enum ParticipantType
+    {
+        Unknown = 0,
+        Chatbot = 1,
+        Dmr = 2,
+        Classifier = 3,
+    }
+}

--- a/src/Dmr.Api/Services/MessageForwarder/MessageForwarderService.cs
+++ b/src/Dmr.Api/Services/MessageForwarder/MessageForwarderService.cs
@@ -50,7 +50,7 @@ namespace Dmr.Api.Services.MessageForwarder
                 // If classification is specified - forward to the classifier.
                 if (payload.Headers.XSendTo == Constants.ClassifierId)
                 {
-                    await SendMessageForClassification(payload.Payload, payload.Headers).ConfigureAwait(false);
+                    await ResolveClassifierAndSend(payload.Payload, payload.Headers).ConfigureAwait(false);
                     return;
                 }
 
@@ -100,18 +100,34 @@ namespace Dmr.Api.Services.MessageForwarder
             }
         }
 
-        private async Task SendMessageForClassification(string payload, HeadersInput headers)
+        private async Task ResolveClassifierAndSend(string payload, HeadersInput headers)
         {
             try
             {
+                var classifiers = await centOps.FetchParticipantsByType(ParticipantType.Classifier).ConfigureAwait(false);
+
+                if (!classifiers.Any())
+                {
+                    throw new KeyNotFoundException($"No Classifiers found.");
+                }
+
+                // For now - just select the first classifier.  This functionality will need to evolve.
+                var classifierInstance = classifiers.First();
+                var classifierUri = new Uri(classifierInstance.Host!);
+
                 using var content = GetDefaultRequestContent(payload, headers);
-                var response = await HttpClient.PostAsync(Config.ClassifierUri, content).ConfigureAwait(false);
+                var response = await HttpClient.PostAsync(classifierUri, content).ConfigureAwait(false);
                 _ = response.EnsureSuccessStatusCode();
             }
             catch (HttpRequestException httpReqException)
             {
                 Logger.ClassifierCallError(httpReqException);
                 throw new MessageForwarderException("Calling classifier failed.", httpReqException);
+            }
+            catch (KeyNotFoundException knfException)
+            {
+                Logger.ClassifierCallError(knfException);
+                throw new MessageForwarderException("No active classifiers found.", knfException);
             }
         }
 

--- a/src/Dmr.Api/Services/MessageForwarder/MessageForwarderService.cs
+++ b/src/Dmr.Api/Services/MessageForwarder/MessageForwarderService.cs
@@ -145,7 +145,7 @@ namespace Dmr.Api.Services.MessageForwarder
                 participantEndpoint = await centOps.FetchEndpointByName(headers.XSentBy).ConfigureAwait(false);
                 if (participantEndpoint == null)
                 {
-                    throw new KeyNotFoundException($"Participant with id '{headers.XSendTo}' not found");
+                    throw new KeyNotFoundException($"Participant with id '{headers.XSentBy}' not found");
                 }
 
                 using var content = GetDefaultRequestContent(string.Empty, headers);

--- a/src/Dmr.Api/Services/MessageForwarder/MessageForwarderSettings.cs
+++ b/src/Dmr.Api/Services/MessageForwarder/MessageForwarderSettings.cs
@@ -7,11 +7,6 @@ namespace Dmr.Api.Services.MessageForwarder
     public class MessageForwarderSettings : AsyncProcessorSettings
     {
         /// <summary>
-        /// Gets or sets the base URI for the Classifier REST API.
-        /// </summary>
-        public Uri? ClassifierUri { get; set; }
-
-        /// <summary>
         /// Gets or sets the base URI for the CentOps REST API.
         /// </summary>
         public Uri? CentOpsUri { get; set; }

--- a/src/Dmr.UnitTests/CentOpsServiceTests.cs
+++ b/src/Dmr.UnitTests/CentOpsServiceTests.cs
@@ -86,7 +86,7 @@ namespace Dmr.UnitTests
         }
 
         [Fact]
-        public async Task ReturnsNoPariticipantsIfNoneOfTypeExist()
+        public async Task ReturnsNoParticipantsIfNoneOfTypeExist()
         {
             // Arrange
             var participant1 = new Participant { Host = "https://classifier/", Id = "1", Name = "classifier", Type = ParticipantType.Classifier };

--- a/src/Dmr.UnitTests/CentOpsServiceTests.cs
+++ b/src/Dmr.UnitTests/CentOpsServiceTests.cs
@@ -21,8 +21,8 @@ namespace Dmr.UnitTests
         public async Task RetreiveItemFromCacheAsync()
         {
             // Arrange
-            var participant1 = new Participant { Host = "https://bot1/", Id = "1", Name = "bot1" };
-            var participant2 = new Participant { Host = "https://bot2/", Id = "2", Name = "bot2" };
+            var participant1 = new Participant { Host = "https://bot1/", Id = "1", Name = "bot1", Type = ParticipantType.Chatbot };
+            var participant2 = new Participant { Host = "https://bot2/", Id = "2", Name = "bot2", Type = ParticipantType.Chatbot };
 
             var participantCache = CreateDictionary(participant1, participant2);
             var sut = new CentOpsService(participantCache);
@@ -38,7 +38,7 @@ namespace Dmr.UnitTests
         public async Task ReturnsNullIfDoesntExistAsync()
         {
             // Arrange
-            var participant = new Participant { Host = "https://bot1/", Id = "1", Name = "bot1" };
+            var participant = new Participant { Host = "https://bot1/", Id = "1", Name = "bot1", Type = ParticipantType.Chatbot };
             var participantCache = CreateDictionary(participant);
             var sut = new CentOpsService(participantCache);
 
@@ -53,7 +53,7 @@ namespace Dmr.UnitTests
         public async Task ReturnsNullIfParticipantHasNoHostAsync()
         {
             // Arrange
-            var participant = new Participant { Host = null, Id = "1", Name = "bot1" };
+            var participant = new Participant { Host = null, Id = "1", Name = "bot1", Type = ParticipantType.Chatbot };
             var participantCache = CreateDictionary(participant);
             var sut = new CentOpsService(participantCache);
 
@@ -62,6 +62,44 @@ namespace Dmr.UnitTests
 
             // Assert
             Assert.Null(endpoint);
+        }
+
+        [Fact]
+        public async Task ReturnsClassifiersByType()
+        {
+            // Arrange
+            var participant1 = new Participant { Host = "https://classifier/", Id = "1", Name = "classifier", Type = ParticipantType.Classifier };
+            var participant2 = new Participant { Host = "https://bot2/", Id = "2", Name = "bot2", Type = ParticipantType.Chatbot };
+
+            var participantCache = CreateDictionary(participant1, participant2);
+            var sut = new CentOpsService(participantCache);
+
+            // Act
+            var classifiers = await sut.FetchParticipantsByType(ParticipantType.Classifier).ConfigureAwait(false);
+
+            // Assert
+            var classifier = Assert.Single(classifiers);
+            Assert.Equal(participant1.Name, classifier.Name);
+            Assert.Equal(participant1.Id, classifier.Id);
+            Assert.Equal(ParticipantType.Classifier, classifier.Type);
+            Assert.Equal(participant1.Host, classifier.Host);
+        }
+
+        [Fact]
+        public async Task ReturnsNoPariticipantsIfNoneOfTypeExist()
+        {
+            // Arrange
+            var participant1 = new Participant { Host = "https://classifier/", Id = "1", Name = "classifier", Type = ParticipantType.Classifier };
+            var participant2 = new Participant { Host = "https://bot2/", Id = "2", Name = "bot2", Type = ParticipantType.Chatbot };
+
+            var participantCache = CreateDictionary(participant1, participant2);
+            var sut = new CentOpsService(participantCache);
+
+            // Act
+            var dmrs = await sut.FetchParticipantsByType(ParticipantType.Dmr).ConfigureAwait(false);
+
+            // Assert
+            Assert.Empty(dmrs);
         }
 
         private static ConcurrentDictionary<string, Participant> CreateDictionary(params Participant[] participants)

--- a/src/Dmr.UnitTests/DmrBaseTest.cs
+++ b/src/Dmr.UnitTests/DmrBaseTest.cs
@@ -1,0 +1,26 @@
+﻿using Dmr.Api.Services.CentOps;
+using Moq;
+
+namespace Dmr.UnitTests
+{
+    public class DmrBaseTest
+    {
+        protected Participant ClassifierParticipant { get; } = new()
+        {
+            Host = "http://classifier",
+            Id = "classifier",
+            Name = "Classifier",
+            Type = ParticipantType.Classifier
+        };
+
+        protected Mock<ICentOpsService> ConfigureMockCentOps()
+        {
+            var mockCentOps = new Mock<ICentOpsService>();
+            _ = mockCentOps
+                .Setup(s => s.FetchParticipantsByType(ParticipantType.Classifier))
+                .ReturnsAsync(new[] { ClassifierParticipant });
+
+            return mockCentOps;
+        }
+    }
+}

--- a/src/Dmr.UnitTests/MessageForwarderServiceLoggingTests.cs
+++ b/src/Dmr.UnitTests/MessageForwarderServiceLoggingTests.cs
@@ -16,7 +16,7 @@ namespace Dmr.UnitTests
     /// <summary>
     /// A collection of tests for the core DMR routing logic as it relates to logging specificially.
     /// </summary>
-    public class MessageForwarderServiceLoggingTests
+    public class MessageForwarderServiceLoggingTests : DmrBaseTest
     {
         /// <summary>
         /// Validates the correct logging is performed when CentOps doesn't have an entry for the destination bot.
@@ -50,7 +50,7 @@ namespace Dmr.UnitTests
 
             var sut = new MessageForwarderService(
                 clientFactory.Object,
-                new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+                new MessageForwarderSettings(),
                 mockCentOps.Object,
                 logger.Object);
 
@@ -101,7 +101,7 @@ namespace Dmr.UnitTests
 
             var sut = new MessageForwarderService(
                 clientFactory.Object,
-                new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+                new MessageForwarderSettings(),
                 mockCentOps.Object,
                 logger.Object);
 
@@ -138,7 +138,7 @@ namespace Dmr.UnitTests
             var sourceChatbotId = "bot1";
             var sourceChatbotEndpoint = new Uri("http://bot1");
 
-            var mockCentOps = new Mock<ICentOpsService>();
+            var mockCentOps = ConfigureMockCentOps();
 
             Mock<ILogger<MessageForwarderService>> logger = new();
             _ = logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
@@ -154,7 +154,7 @@ namespace Dmr.UnitTests
 
             var sut = new MessageForwarderService(
                 clientFactory.Object,
-                new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+                new MessageForwarderSettings(),
                 mockCentOps.Object,
                 logger.Object);
 

--- a/src/Dmr.UnitTests/MessageForwarderServiceTests.cs
+++ b/src/Dmr.UnitTests/MessageForwarderServiceTests.cs
@@ -15,7 +15,7 @@ namespace Dmr.UnitTests
     /// <summary>
     /// A collection of tests for the core DMR routing logic.
     /// </summary>
-    public class MessageForwarderServiceTests
+    public class MessageForwarderServiceTests : DmrBaseTest
     {
         private const string DefaultModelType = "application/vnd.buerokratt;version=1";
 
@@ -28,10 +28,11 @@ namespace Dmr.UnitTests
 
             // Act && Assert
             _ = Assert.Throws<ArgumentNullException>(
-                () => new MessageForwarderService(null,
-                 new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
-                mockCentOps.Object,
-                logger.Object));
+                () => new MessageForwarderService(
+                    null,
+                    new MessageForwarderSettings(),
+                    mockCentOps.Object,
+                    logger.Object));
         }
 
         [Fact]
@@ -45,32 +46,33 @@ namespace Dmr.UnitTests
 
             // Act && Assert
             _ = Assert.Throws<ArgumentNullException>(
-                () => new MessageForwarderService(null,
-               null,
-                mockCentOps.Object,
-                logger.Object));
+                () => new MessageForwarderService(
+                    null,
+                    null,
+                    mockCentOps.Object,
+                    logger.Object));
         }
 
         [Fact]
         public async Task MessageForwarderProcessesEnqueuedMessages()
         {
             // Arrange
-            var mockCentOps = new Mock<ICentOpsService>();
+            var mockCentOps = ConfigureMockCentOps();
             Mock<ILogger<MessageForwarderService>> logger = new();
             using MockHttpMessageHandler httpMessageHandler = new();
             var clientFactory = GetHttpClientFactory(httpMessageHandler);
 
             var sut = new MessageForwarderService(
                clientFactory.Object,
-               new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+               new MessageForwarderSettings(),
                mockCentOps.Object,
                logger.Object);
 
             // Expect the classifier to be called twice.
-            _ = httpMessageHandler.Expect(HttpMethod.Post, "http://classifier")
+            _ = httpMessageHandler.Expect(HttpMethod.Post, ClassifierParticipant.Host)
                 .Respond(HttpStatusCode.Accepted);
 
-            _ = httpMessageHandler.Expect(HttpMethod.Post, "http://classifier")
+            _ = httpMessageHandler.Expect(HttpMethod.Post, ClassifierParticipant.Host)
                 .Respond(HttpStatusCode.Accepted);
 
             // Act
@@ -245,14 +247,15 @@ namespace Dmr.UnitTests
         public async Task ProcessRequestAsyncCallsClassifierIfSpecified()
         {
             // Arrange
-            var mockCentOps = new Mock<ICentOpsService>();
+            var mockCentOps = ConfigureMockCentOps();
+
             Mock<ILogger<MessageForwarderService>> logger = new();
             _ = logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
 
             using MockHttpMessageHandler httpMessageHandler = new();
 
             _ = httpMessageHandler
-                .Expect(HttpMethod.Post, "http://classifier")
+                .Expect(HttpMethod.Post, ClassifierParticipant.Host)
                 .WithHeaders(Constants.XSentByHeaderName, "Police")
                 .WithHeaders(Constants.XSendToHeaderName, Constants.ClassifierId)
                 .WithHeaders(Constants.XModelTypeHeaderName, DefaultModelType)
@@ -265,7 +268,7 @@ namespace Dmr.UnitTests
 
             var sut = new MessageForwarderService(
                 clientFactory.Object,
-                new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+                new MessageForwarderSettings(),
                 mockCentOps.Object,
                 logger.Object);
 
@@ -325,7 +328,7 @@ namespace Dmr.UnitTests
 
             var sut = new MessageForwarderService(
                 clientFactory.Object,
-                new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+                new MessageForwarderSettings(),
                 mockCentOps.Object,
                 logger.Object);
 
@@ -358,7 +361,7 @@ namespace Dmr.UnitTests
             var sourceChatbotId = "bot1";
             var sourceChatbotEndpoint = new Uri("http://bot1");
 
-            var mockCentOps = new Mock<ICentOpsService>();
+            var mockCentOps = ConfigureMockCentOps();
             _ = mockCentOps.Setup(m => m.FetchEndpointByName(sourceChatbotId)).Returns(Task.FromResult(sourceChatbotEndpoint));
 
             Mock<ILogger<MessageForwarderService>> logger = new();
@@ -366,7 +369,7 @@ namespace Dmr.UnitTests
 
             // Classifier call fails.
             _ = httpMessageHandler
-                .Expect(HttpMethod.Post, "http://classifier")
+                .Expect(HttpMethod.Post, ClassifierParticipant.Host)
                 .Respond(HttpStatusCode.InternalServerError);
 
             // Source chatbot receives error callback.
@@ -383,7 +386,7 @@ namespace Dmr.UnitTests
 
             var sut = new MessageForwarderService(
                 clientFactory.Object,
-                new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+                new MessageForwarderSettings(),
                 mockCentOps.Object,
                 logger.Object);
 
@@ -442,7 +445,7 @@ namespace Dmr.UnitTests
 
             var sut = new MessageForwarderService(
                 clientFactory.Object,
-                new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+                new MessageForwarderSettings(),
                 mockCentOps.Object,
                 logger.Object);
 
@@ -502,7 +505,7 @@ namespace Dmr.UnitTests
 
             var sut = new MessageForwarderService(
                 clientFactory.Object,
-                new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier") },
+                new MessageForwarderSettings(),
                 mockCentOps.Object,
                 logger.Object);
 

--- a/src/Dmr.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/src/Dmr.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -23,7 +23,7 @@ namespace Dmr.UnitTests
         {
             // Arrange
             var services = new ServiceCollection();
-            var settings = new MessageForwarderSettings { ClassifierUri = new Uri("http://classifier"), CentOpsUri = new Uri("http://centops") };
+            var settings = new MessageForwarderSettings { CentOpsUri = new Uri("http://centops") };
 
             //Act
             ServiceCollectionExtensions.AddMessageForwarder(services, settings);


### PR DESCRIPTION
This PR brings in Classifier configuration from CentOps.
This took a little longer than expected owing to a weird serialization issue, which I've sorted out now.

Currently - we're just selecting the first classifier we find until a better mechanism is decided upon.  

This change is going to have a knock-on effect with the integration tests (which will need a little more setup as a result).  So we need to handle committing this carefully.